### PR TITLE
Fix for libraries not loading on Windows.

### DIFF
--- a/src/main/java/io/portx/datasonnet/util/ClasspathUtils.java
+++ b/src/main/java/io/portx/datasonnet/util/ClasspathUtils.java
@@ -13,6 +13,7 @@ import com.intellij.psi.util.ParameterizedCachedValue;
 import com.intellij.psi.util.ParameterizedCachedValueProvider;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -77,7 +78,9 @@ public final class ClasspathUtils {
 
             String fullClasspath = OrderEnumerator.orderEntries(module).recursively().getPathsList().getPathsString();
 
-            String[] cpEntries = fullClasspath.split(":");
+            // Windows uses semicolons as the path separator and Linux uses colons. We need to split the classpath
+            // based on the correct separator.
+            String[] cpEntries = fullClasspath.split(File.pathSeparator);
             for (String nextEntry : cpEntries) {
                 try {
                     URL url = nextEntry.endsWith(".jar") ? URI.create("jar:file://" + nextEntry + "!/").toURL() : URI.create("file://" + nextEntry).toURL();
@@ -90,6 +93,9 @@ public final class ClasspathUtils {
             CompilerModuleExtension extension = CompilerModuleExtension.getInstance(module);
             String[] outputRootUrls = extension.getOutputRootUrls(false);
             for (String nextUrlString : outputRootUrls) {
+                // URI does not accept backslashes. Windows paths are returned with backslashes, so we need to
+                // replace them with forward slashes.
+                nextUrlString = nextUrlString.replaceAll("\\\\", "/");
                 if (!nextUrlString.endsWith("/")) {
                     nextUrlString = nextUrlString + "/";
                 }


### PR DESCRIPTION
Fixes the error that on Windows custom DataSonnet libraries are not loaded when added as dependency to your project. This is because of the use of invalid path separator and using "\" in URIs o Windows which is not supported.